### PR TITLE
Revert "Pushing first draft of lecture 5" 

### DIFF
--- a/exercises/02-textures/main.cpp
+++ b/exercises/02-textures/main.cpp
@@ -26,7 +26,7 @@ float     gScaleFactor   = SIZE,
 Vector2   gPosition      = ORIGIN;
 Vector2   gScale         = BASE_SIZE;
 
-Texture2D gTeardropTexture;
+Texture2D gTexture;
 
 // Function Declarations
 void initialise();
@@ -40,7 +40,7 @@ void initialise()
 {
     InitWindow(SCREEN_WIDTH, SCREEN_HEIGHT, "Textures");
 
-    gTeardropTexture = LoadTexture(ALBUM_COVER_FP);
+    gTexture = LoadTexture(ALBUM_COVER_FP);
 
     SetTargetFPS(FPS);
 }
@@ -86,8 +86,8 @@ void render()
         0.0f, 0.0f,
 
         // bottom-right corner (of texture)
-        static_cast<float>(gTeardropTexture.width),
-        static_cast<float>(gTeardropTexture.height)
+        static_cast<float>(gTexture.width),
+        static_cast<float>(gTexture.height)
     };
 
     // Destination rectangle – centred on gPosition
@@ -106,7 +106,7 @@ void render()
 
     // Render the texture on screen
     DrawTexturePro(
-        gTeardropTexture, 
+        gTexture, 
         textureArea, 
         destinationArea, 
         objectOrigin, 

--- a/exercises/02-textures/solution.cpp
+++ b/exercises/02-textures/solution.cpp
@@ -39,7 +39,7 @@ float     gPreviousTicks = 0.0f;
 Member    gCurrentMember = NOODLE;
 int       gFrameCounter  = 0;
 
-Texture2D gTeardropTexture;
+Texture2D gTexture;
 
 // Function Declarations
 void initialise();
@@ -53,7 +53,7 @@ void initialise()
 {
     InitWindow(SCREEN_WIDTH, SCREEN_HEIGHT, "Textures");
 
-    gTeardropTexture = LoadTexture(ALBUM_COVER_FP);
+    gTexture = LoadTexture(ALBUM_COVER_FP);
 
     SetTargetFPS(FPS);
 }
@@ -110,12 +110,12 @@ void render()
         are starting from half-way length- and/or width-wise, depending
         on the member.
         */
-        switches[0] ? 0.0f : static_cast<float>(gTeardropTexture.width)  / 2.0f,
-        switches[1] ? 0.0f : static_cast<float>(gTeardropTexture.height) / 2.0f,
+        switches[0] ? 0.0f : static_cast<float>(gTexture.width)  / 2.0f,
+        switches[1] ? 0.0f : static_cast<float>(gTexture.height) / 2.0f,
 
         // bottom-right corner (of texture)
-        static_cast<float>(gTeardropTexture.width)  / 2.0f,
-        static_cast<float>(gTeardropTexture.height) / 2.0f
+        static_cast<float>(gTexture.width)  / 2.0f,
+        static_cast<float>(gTexture.height) / 2.0f
     };
 
     // Destination rectangle – centred on gPosition
@@ -134,7 +134,7 @@ void render()
 
     // Render the texture on screen
     DrawTexturePro(
-        gTeardropTexture, 
+        gTexture, 
         textureArea, 
         destinationArea, 
         objectOrigin, 
@@ -148,7 +148,7 @@ void render()
 void shutdown() 
 { 
     CloseWindow();
-    UnloadTexture(gTeardropTexture);
+    UnloadTexture(gTexture);
 }
 
 int main(void)

--- a/exercises/03-collisions/main.cpp
+++ b/exercises/03-collisions/main.cpp
@@ -34,7 +34,7 @@ Vector2 gTeardropPosition = TEARDROP_INIT_POS,
 
         gMousePosition = GetMousePosition();
 
-Texture2D gTeardropTexture;
+Texture2D gTexture;
 Texture2D gBeakerTexture;
 
 TeardropStatus gTeardropStatus = HANGING;
@@ -114,7 +114,7 @@ void initialise()
     InitWindow(SCREEN_WIDTH, SCREEN_HEIGHT, 
         "User Input / Collision Detection");
 
-    gTeardropTexture = LoadTexture(TEARDROP_FP);
+    gTexture = LoadTexture(TEARDROP_FP);
     gBeakerTexture   = LoadTexture(BEAKER_FP);
 
     SetTargetFPS(FPS);
@@ -159,7 +159,7 @@ void render()
     ClearBackground(RAYWHITE);
 
     // render teardrop
-    renderObject(&gTeardropTexture, &gTeardropPosition, &gScale);
+    renderObject(&gTexture, &gTeardropPosition, &gScale);
 
     // render the rupee
     renderObject(&gBeakerTexture, &gBeakerPosition, &gBeakerScale);
@@ -171,7 +171,7 @@ void shutdown()
 { 
     CloseWindow();
     UnloadTexture(gBeakerTexture);
-    UnloadTexture(gTeardropTexture);
+    UnloadTexture(gTexture);
 }
 
 int main(void)

--- a/exercises/03-collisions/solution.cpp
+++ b/exercises/03-collisions/solution.cpp
@@ -36,7 +36,7 @@ Vector2 gPosition = TEARDROP_INIT_POS,
 
 Vector4 gTeardropCorners  = { };
 
-Texture2D gTeardropTexture;
+Texture2D gTexture;
 Texture2D gBeakerTexture;
 
 TeardropStatus gTeardropStatus = HANGING;
@@ -115,8 +115,8 @@ void initialise()
 {
     InitWindow(SCREEN_WIDTH, SCREEN_HEIGHT, "User Input / Collision Detection");
 
-    gTeardropTexture = LoadTexture(TEARDROP_FP);
-    gBeakerTexture = LoadTexture(BEAKER_FP);
+    gTexture = LoadTexture(TEARDROP_FP);
+    gBeakerTexture   = LoadTexture(BEAKER_FP);
 
     SetTargetFPS(FPS);
 }
@@ -182,7 +182,7 @@ void render()
     ClearBackground(RAYWHITE);
 
     // Render teardrop
-    renderObject(&gTeardropTexture, &gPosition, &gScale);
+    renderObject(&gTexture, &gPosition, &gScale);
 
     // Render the rupee
     renderObject(&gBeakerTexture, &gBeakerPosition, &gBeakerScale);

--- a/lectures/03-textures-delta-time/main.cpp
+++ b/lectures/03-textures-delta-time/main.cpp
@@ -24,7 +24,7 @@ Vector2   gPosition      = ORIGIN;
 Vector2   gScale         = BASE_SIZE;
 float     gPreviousTicks = 0.0f;
 
-Texture2D gTeardropTexture;
+Texture2D gTexture;
 
 // Function Declarations
 void initialise();
@@ -38,7 +38,7 @@ void initialise()
 {
     InitWindow(SCREEN_WIDTH, SCREEN_HEIGHT, "Textures");
 
-    gTeardropTexture = LoadTexture(LINK_FP);
+    gTexture = LoadTexture(LINK_FP);
 
     SetTargetFPS(FPS);
 }
@@ -74,8 +74,8 @@ void render()
         0.0f, 0.0f,
 
         // bottom-right corner (of texture)
-        static_cast<float>(gTeardropTexture.width),
-        static_cast<float>(gTeardropTexture.height)
+        static_cast<float>(gTexture.width),
+        static_cast<float>(gTexture.height)
     };
 
     // Destination rectangle – centred on gPosition
@@ -94,7 +94,7 @@ void render()
 
     // Render the texture on screen
     DrawTexturePro(
-        gTeardropTexture, 
+        gTexture, 
         textureArea, 
         destinationArea, 
         objectOrigin, 
@@ -108,7 +108,7 @@ void render()
 void shutdown() 
 { 
     CloseWindow(); 
-    UnloadTexture(gTeardropTexture);
+    UnloadTexture(gTexture);
 }
 
 int main(void)

--- a/lectures/04-user-input-collisions/main.cpp
+++ b/lectures/04-user-input-collisions/main.cpp
@@ -32,7 +32,7 @@ Vector2 gPosition  = INIT_POS,
 
         gMousePosition = GetMousePosition();
 
-Texture2D gLinkTexture;
+Texture2D gTexture;
 Texture2D gRupeeTexture;
 
 unsigned int startTime;
@@ -111,7 +111,7 @@ void initialise()
 
     startTime = time(NULL);
 
-    gLinkTexture  = LoadTexture(LINK_FP);
+    gTexture  = LoadTexture(LINK_FP);
     gRupeeTexture = LoadTexture(RUPEE_FP);
 
     SetTargetFPS(FPS);
@@ -171,7 +171,7 @@ void render()
     ClearBackground(ColorFromHex(BG_COLOUR));
 
     // Render Link
-    renderObject(&gLinkTexture, &gPosition, &gScale);
+    renderObject(&gTexture, &gPosition, &gScale);
 
     // Render the rupee
     renderObject(&gRupeeTexture, &gRupeePosition, &gRupeeScale);
@@ -182,7 +182,7 @@ void render()
 void shutdown() 
 { 
     CloseWindow(); 
-    UnloadTexture(gLinkTexture);
+    UnloadTexture(gTexture);
     UnloadTexture(gRupeeTexture);
 }
 


### PR DESCRIPTION
revert pushing of https://github.com/sebastianromerocruz/CS-3113-Intro-To-Game-Programming/commit/bfd724bda495eb862ea29e16dbe72e06f9d262fd

 - Restores original texture symbol names (gTexture, gLinkTexture) across lecture and exercise sources
  to match the pre-commit API surface (exercises/02-textures/main.cpp:26, exercises/02-textures/
  solution.cpp:39, exercises/03-collisions/main.cpp:34, exercises/03-collisions/solution.cpp:36,
  lectures/03-textures-delta-time/main.cpp:24, lectures/04-user-input-collisions/main.cpp:32).
  - Reverts the associated load/render/unload calls so the pre-existing helper functions keep working
  (exercises/02-textures/main.cpp:40, exercises/02-textures/main.cpp:86, exercises/02-textures/
  main.cpp:106; similar adjustments in the paired solution file and lecture sources noted above).
  - README banner that links to lecture 5 remains untouched per request.
