### PR TITLE
fix ENTITY_H and dound

### DIFF
--- a/exercises/05-physics/CS3113/Entity.cpp
+++ b/exercises/05-physics/CS3113/Entity.cpp
@@ -89,7 +89,7 @@ void Entity::checkCollisionX(Entity *collidableEntities, int collisionCheckCount
         {            
             // When standing on a platform, we're always slightly overlapping
             // it vertically due to gravity, which causes false horizontal
-            // collision detections. So the solution I dound is only resolve X
+            // collision detections. So the solution I found is only resolve X
             // collisions if there's significant Y overlap, preventing the 
             // platform we're standing on from acting like a wall.
             float yDistance = fabs(mPosition.y - collidableEntity->mPosition.y);

--- a/exercises/05-physics/solution/CS3113/Entity.cpp
+++ b/exercises/05-physics/solution/CS3113/Entity.cpp
@@ -92,7 +92,7 @@ void Entity::checkCollisionX(Entity *collidableEntities, int collisionCheckCount
         {            
             // When standing on a platform, we're always slightly overlapping
             // it vertically due to gravity, which causes false horizontal
-            // collision detections. So the solution I dound is only resolve X
+            // collision detections. So the solution I found is only resolve X
             // collisions if there's significant Y overlap, preventing the 
             // platform we're standing on from acting like a wall.
             float yDistance = fabs(mPosition.y - collidableEntity->mPosition.y);

--- a/exercises/07-maps/CS3113/Entity.cpp
+++ b/exercises/07-maps/CS3113/Entity.cpp
@@ -77,7 +77,7 @@ void Entity::checkCollisionX(Entity *collidableEntities, int collisionCheckCount
         {            
             // When standing on a platform, we're always slightly overlapping
             // it vertically due to gravity, which causes false horizontal
-            // collision detections. So the solution I dound is only resolve X
+            // collision detections. So the solution I found is only resolve X
             // collisions if there's significant Y overlap, preventing the 
             // platform we're standing on from acting like a wall.
             float yDistance = fabs(mPosition.y - collidableEntity->mPosition.y);

--- a/exercises/07-maps/solution/CS3113/Entity.cpp
+++ b/exercises/07-maps/solution/CS3113/Entity.cpp
@@ -77,7 +77,7 @@ void Entity::checkCollisionX(Entity *collidableEntities, int collisionCheckCount
         {            
             // When standing on a platform, we're always slightly overlapping
             // it vertically due to gravity, which causes false horizontal
-            // collision detections. So the solution I dound is only resolve X
+            // collision detections. So the solution I found is only resolve X
             // collisions if there's significant Y overlap, preventing the 
             // platform we're standing on from acting like a wall.
             float yDistance = fabs(mPosition.y - collidableEntity->mPosition.y);

--- a/lectures/06-physics/CS3113/Entity.cpp
+++ b/lectures/06-physics/CS3113/Entity.cpp
@@ -86,7 +86,7 @@ void Entity::checkCollisionX(Entity *collidableEntities, int collisionCheckCount
         {            
             // When standing on a platform, we're always slightly overlapping
             // it vertically due to gravity, which causes false horizontal
-            // collision detections. So the solution I dound is only resolve X
+            // collision detections. So the solution I found is only resolve X
             // collisions if there's significant Y overlap, preventing the 
             // platform we're standing on from acting like a wall.
             float yDistance = fabs(mPosition.y - collidableEntity->mPosition.y);

--- a/lectures/06-physics/README.md
+++ b/lectures/06-physics/README.md
@@ -695,7 +695,7 @@ void Entity::checkCollisionX(Entity *collidableEntities, int collisionCheckCount
             
             // When standing on a platform, we're always slightly overlapping
             // it vertically due to gravity, which causes false horizontal
-            // collision detections. So the solution I dound is only resolve X
+            // collision detections. So the solution I found is only resolve X
             // collisions if there's significant Y overlap, preventing the 
             // platform we're standing on from acting like a wall.
             float yDistance = fabs(mPosition.y - collidableEntity->mPosition.y);

--- a/lectures/07-ai/CS3113/Entity.cpp
+++ b/lectures/07-ai/CS3113/Entity.cpp
@@ -92,7 +92,7 @@ void Entity::checkCollisionX(Entity *collidableEntities, int collisionCheckCount
         {            
             // When standing on a platform, we're always slightly overlapping
             // it vertically due to gravity, which causes false horizontal
-            // collision detections. So the solution I dound is only resolve X
+            // collision detections. So the solution I found is only resolve X
             // collisions if there's significant Y overlap, preventing the 
             // platform we're standing on from acting like a wall.
             float yDistance = fabs(mPosition.y - collidableEntity->mPosition.y);

--- a/lectures/08-maps/CS3113/Entity.cpp
+++ b/lectures/08-maps/CS3113/Entity.cpp
@@ -77,7 +77,7 @@ void Entity::checkCollisionX(Entity *collidableEntities, int collisionCheckCount
         {            
             // When standing on a platform, we're always slightly overlapping
             // it vertically due to gravity, which causes false horizontal
-            // collision detections. So the solution I dound is only resolve X
+            // collision detections. So the solution I found is only resolve X
             // collisions if there's significant Y overlap, preventing the 
             // platform we're standing on from acting like a wall.
             float yDistance = fabs(mPosition.y - collidableEntity->mPosition.y);

--- a/lectures/09-scenes/CS3113/Entity.cpp
+++ b/lectures/09-scenes/CS3113/Entity.cpp
@@ -77,7 +77,7 @@ void Entity::checkCollisionX(Entity *collidableEntities, int collisionCheckCount
         {            
             // When standing on a platform, we're always slightly overlapping
             // it vertically due to gravity, which causes false horizontal
-            // collision detections. So the solution I dound is only resolve X
+            // collision detections. So the solution I found is only resolve X
             // collisions if there's significant Y overlap, preventing the 
             // platform we're standing on from acting like a wall.
             float yDistance = fabs(mPosition.y - collidableEntity->mPosition.y);

--- a/lectures/10-effects-shaders/CS3113/Entity.cpp
+++ b/lectures/10-effects-shaders/CS3113/Entity.cpp
@@ -77,7 +77,7 @@ void Entity::checkCollisionX(Entity *collidableEntities, int collisionCheckCount
         {            
             // When standing on a platform, we're always slightly overlapping
             // it vertically due to gravity, which causes false horizontal
-            // collision detections. So the solution I dound is only resolve X
+            // collision detections. So the solution I found is only resolve X
             // collisions if there's significant Y overlap, preventing the 
             // platform we're standing on from acting like a wall.
             float yDistance = fabs(mPosition.y - collidableEntity->mPosition.y);

--- a/lectures/10-effects-shaders/CS3113/Entity.h
+++ b/lectures/10-effects-shaders/CS3113/Entity.h
@@ -165,4 +165,4 @@ public:
         { mAIType = newType;                       }
 };
 
-#endif // ENTITY_CPP
+#endif // ENTITY_H


### PR DESCRIPTION
This pull request makes minor corrections across several files, mainly fixing a typo in a comment and correcting a header guard. These changes improve code clarity and maintain consistency in documentation.

Documentation and comment corrections:

* Fixed a typo in comments within the `checkCollisionX` method in multiple `Entity.cpp` files (from "dound" to "found") to improve readability. [[1]](diffhunk://#diff-9b1f6168d42026fdcaae9923b0891cdb887188a8fdd60d5db816e584e33a7192L92-R92) [[2]](diffhunk://#diff-2206ed16929408b4fb363bd3da66f500448652c1fcdf07448f9a866c7e9990bcL95-R95) [[3]](diffhunk://#diff-2947e9bc418a4e8341e2598b44bb6cbd191f8383d7019420efb7af88a48834cfL80-R80) [[4]](diffhunk://#diff-b7edb77224581033a78468bbc16976a0ce863660176be1d91fc2594177e4bc5bL80-R80) [[5]](diffhunk://#diff-3794877bc9bbc13e9a88b97cc407f89c8a9bc2dbeb97f11c3f162090ba7546dcL89-R89) [[6]](diffhunk://#diff-1398a4d3a3d0bbb6d1dba2ef97ea2a06bf2100ac1676d8d54c24302836f44e16L95-R95) [[7]](diffhunk://#diff-0f91f82610dc0dd0a307adab40a3093080618f2867bf0c90429293bad15c92adL80-R80) [[8]](diffhunk://#diff-cd7221d3064e17d22c1313a0e25210aeb3b486f0439d79927ada8c704ce645b2L80-R80) [[9]](diffhunk://#diff-b4a20d2b3ea8be1ac0875a143adf6ccf7738ce81f1d218c27521f7776a798b73L80-R80) [[10]](diffhunk://#diff-234651c22ed4498224bffc4ea070d6ef4168a2e527a87d91c7dc61706cd4e95aL698-R698)

Header guard fix:

* Corrected the header guard in `Entity.h` from `ENTITY_CPP` to `ENTITY_H` to match standard conventions and prevent potential compilation issues.