### PR TITLE
fix from debugging during office hour

### DIFF
--- a/lectures/05-animation-entities/CS3113/entities/Entity.h
+++ b/lectures/05-animation-entities/CS3113/entities/Entity.h
@@ -58,7 +58,7 @@ public:
     Vector2     getPosition()              const { return mPosition;              }
     Vector2     getMovement()              const { return mMovement;              }
     Vector2     getScale()                 const { return mScale;                 }
-    Vector2     getColliderDimensions()    const { return mScale;                 }
+    Vector2     getColliderDimensions()    const { return mColliderDimensions;    }
     Vector2     getSpriteSheetDimensions() const { return mSpriteSheetDimensions; }
     Texture2D   getTexture()               const { return mTexture;               }
     TextureType getTextureType()           const { return mTextureType;           }

--- a/lectures/06-physics/CS3113/Entity.h
+++ b/lectures/06-physics/CS3113/Entity.h
@@ -91,7 +91,7 @@ public:
     Vector2     getVelocity()              const { return mVelocity;              }
     Vector2     getAcceleration()          const { return mAcceleration;          }
     Vector2     getScale()                 const { return mScale;                 }
-    Vector2     getColliderDimensions()    const { return mScale;                 }
+    Vector2     getColliderDimensions()    const { return mColliderDimensions;    }
     Vector2     getSpriteSheetDimensions() const { return mSpriteSheetDimensions; }
     Texture2D   getTexture()               const { return mTexture;               }
     TextureType getTextureType()           const { return mTextureType;           }

--- a/lectures/07-ai/CS3113/Entity.h
+++ b/lectures/07-ai/CS3113/Entity.h
@@ -104,7 +104,7 @@ public:
     Vector2     getVelocity()              const { return mVelocity;              }
     Vector2     getAcceleration()          const { return mAcceleration;          }
     Vector2     getScale()                 const { return mScale;                 }
-    Vector2     getColliderDimensions()    const { return mScale;                 }
+    Vector2     getColliderDimensions()    const { return mColliderDimensions;    }
     Vector2     getSpriteSheetDimensions() const { return mSpriteSheetDimensions; }
     Texture2D   getTexture()               const { return mTexture;               }
     TextureType getTextureType()           const { return mTextureType;           }

--- a/lectures/08-maps/CS3113/Entity.h
+++ b/lectures/08-maps/CS3113/Entity.h
@@ -109,7 +109,7 @@ public:
     Vector2     getVelocity()              const { return mVelocity;              }
     Vector2     getAcceleration()          const { return mAcceleration;          }
     Vector2     getScale()                 const { return mScale;                 }
-    Vector2     getColliderDimensions()    const { return mScale;                 }
+    Vector2     getColliderDimensions()    const { return mColliderDimensions;    }
     Vector2     getSpriteSheetDimensions() const { return mSpriteSheetDimensions; }
     Texture2D   getTexture()               const { return mTexture;               }
     TextureType getTextureType()           const { return mTextureType;           }

--- a/lectures/09-scenes/CS3113/Entity.h
+++ b/lectures/09-scenes/CS3113/Entity.h
@@ -109,7 +109,7 @@ public:
     Vector2     getVelocity()              const { return mVelocity;              }
     Vector2     getAcceleration()          const { return mAcceleration;          }
     Vector2     getScale()                 const { return mScale;                 }
-    Vector2     getColliderDimensions()    const { return mScale;                 }
+    Vector2     getColliderDimensions()    const { return mColliderDimensions;    }
     Vector2     getSpriteSheetDimensions() const { return mSpriteSheetDimensions; }
     Texture2D   getTexture()               const { return mTexture;               }
     TextureType getTextureType()           const { return mTextureType;           }

--- a/lectures/09-scenes/CS3113/Scene.h
+++ b/lectures/09-scenes/CS3113/Scene.h
@@ -32,8 +32,8 @@ public:
     virtual void render() = 0;
     virtual void shutdown() = 0;
     
-    GameState   getState()           const { return mGameState; }
-    Vector2     getOrigin()          const { return mOrigin;    }
+    GameState&   getState()           const { return mGameState; }
+    Vector2      getOrigin()          const { return mOrigin;    }
     const char* getBGColourHexCode() const { return mBGColourHexCode; }
 };
 

--- a/lectures/10-effects-shaders/CS3113/Entity.h
+++ b/lectures/10-effects-shaders/CS3113/Entity.h
@@ -109,7 +109,7 @@ public:
     Vector2     getVelocity()              const { return mVelocity;              }
     Vector2     getAcceleration()          const { return mAcceleration;          }
     Vector2     getScale()                 const { return mScale;                 }
-    Vector2     getColliderDimensions()    const { return mScale;                 }
+    Vector2     getColliderDimensions()    const { return mColliderDimensions;    }
     Vector2     getSpriteSheetDimensions() const { return mSpriteSheetDimensions; }
     Texture2D   getTexture()               const { return mTexture;               }
     TextureType getTextureType()           const { return mTextureType;           }

--- a/lectures/10-effects-shaders/CS3113/Scene.h
+++ b/lectures/10-effects-shaders/CS3113/Scene.h
@@ -32,8 +32,8 @@ public:
     virtual void render() = 0;
     virtual void shutdown() = 0;
     
-    GameState   getState()           const { return mGameState; }
-    Vector2     getOrigin()          const { return mOrigin;    }
+    GameState&   getState()           const { return mGameState; }
+    Vector2      getOrigin()          const { return mOrigin;    }
     const char* getBGColourHexCode() const { return mBGColourHexCode; }
 };
 


### PR DESCRIPTION
getState() in Scene.h now returns a reference and getColliderDimensions() returns the correct collider dimension now.